### PR TITLE
Move frontend dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,12 +48,7 @@
         }
     },
     "dependencies": {
-        "@material-ui/core": "^4.10.2",
-        "@material-ui/lab": "^4.0.0-alpha.56",
         "electron-is-dev": "^1.2.0",
-        "overmind": "^24.1.1",
-        "overmind-react": "^25.1.1",
-        "react-router-dom": "^5.2.0"
     },
     "devDependencies": {
         "concurrently": "^5.1.0",
@@ -63,7 +58,12 @@
         "nodemon": "^2.0.3",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
-        "react-scripts": "3.4.1"
+        "react-scripts": "3.4.1",
+        "overmind": "^24.1.1",
+        "overmind-react": "^25.1.1",
+        "react-router-dom": "^5.2.0",
+        "@material-ui/core": "^4.10.2",
+        "@material-ui/lab": "^4.0.0-alpha.56",
     },
     "browserslist": {
         "production": [


### PR DESCRIPTION
It's important to keep frontend dependencies in devDependencies, as it shouldn't be included in production build.